### PR TITLE
Bring mochad up to date with current libraries and declaration conventions

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -23,7 +23,12 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <sys/timeb.h>
+#if 0
+  // ftime() has been deprecated
+  #include <sys/timeb.h>
+#else
+  #include <time.h>
+#endif
 #include "global.h"
 #include "decode.h"
 #include "x10state.h"
@@ -586,10 +591,17 @@ typedef uint64_t timems_t;
 /* Get system time in milliseconds */
 static timems_t get_timems(void)
 {
+#if 0
     struct timeb tp;
 
     ftime(&tp);
     return (timems_t) (tp.time * 1000) + tp.millitm;
+#else
+    struct timespec tp;
+
+    clock_gettime(CLOCK_MONOTONIC,&tp);
+    return (timems_t) ( tp.tv_nsec + (1000 * tp.tv_sec) );
+#endif
 }
 
 #define DUP_TIME (650)

--- a/encode.c
+++ b/encode.c
@@ -88,6 +88,11 @@
 #include "x10state.h"
 #include "x10_write.h"
 
+// These are  actually defined in mochad.c, but there's no .h file.
+// So as a quick make-it-available-without-warnings, declare here
+int or20client(int fd);
+int del_client(int fd);
+
 static void strupper(char *buf)
 {
     while (*buf) {

--- a/encode.h
+++ b/encode.h
@@ -20,4 +20,3 @@
 int processcommandline(int fd, char *aLine);
 
 void cm15a_encode(int fd, unsigned char * buf, size_t buflen);
-

--- a/global.h
+++ b/global.h
@@ -22,13 +22,14 @@ struct SecEventRec {
     const char *name;
 };
 
-int Cm19a;
-int PollTimeOut;
+// Extern to avoid double-declaration complaints
+extern int Cm19a;
+extern int PollTimeOut;
 
 /* 1 bit per house code, 1=RF to PL, 0=off, default all house codes on */
-unsigned short RfToPl16;
+extern unsigned short RfToPl16;
 
-unsigned short RfToRf16;
+extern unsigned short RfToRf16;
 
 
 #define dbprintf(fmt, ...) _dbprintf(fmt, __FILE__,__LINE__, ## __VA_ARGS__)

--- a/mochad.c
+++ b/mochad.c
@@ -565,9 +565,17 @@ static int mydaemon(void)
         dbprintf("failed to initialise libusb %d\n", r);
         exit(1);
     }
-    libusb_set_debug(NULL, 3);
-
+    // libusb_set_debug deprecated; the replacement is
+    // libusb_set_option(libusb_context, LIBUSB_OPTION_LOG_LEVEL, libusb_log_level);libusb_set_option(libusb_context, LIBUSB_OPTION_LOG_LEVEL, libusb_log_level);
 #if 0
+    libusb_set_debug(NULL, 3);
+#else
+    libusb_set_option(NULL,
+        LIBUSB_OPTION_LOG_LEVEL,
+        LIBUSB_LOG_LEVEL_INFO); // may be excessive
+#endif
+
+#if 1
     /* This function is not available in older versions of libusb-1.0 */
     r = libusb_pollfds_handle_timeouts(NULL);
     if (!r) {

--- a/mochad.c
+++ b/mochad.c
@@ -537,6 +537,9 @@ static void sighandler(int signum)
     Do_exit = 1;	
 }
 
+int PollTimeOut=-1;
+
+
 static int mydaemon(void)
 {
     int nready, i;


### PR DESCRIPTION
As cloned today, mochad did not build for me on a current Raspbian system; warnings were produced about deprecated library functions and multiply defined globals.  With the default compiler options, these kept the program from linking.

Yes, I could have just weakened the compiler error checking, but I preferred to actually address the complaints. This changeset attempts to swap in modern versions of the debatable code.

Caveat: INADEQUATELY TESTED at this time; I don't have enough of a mochad/X10 environment set up yet to exercise it properly. I'd recommend getting folks to sanity-check, and try out, these changes before merging.

Hope this is helpful.